### PR TITLE
Feature/link type

### DIFF
--- a/app/models/base.coffee
+++ b/app/models/base.coffee
@@ -52,7 +52,7 @@ class BaseCollection extends Chaplin.Collection
       if links = resp.links
         @links = links
 
-      for key, value of resp when key not in ['links', resourceName]
+      for key, value of resp when key isnt 'links'
         (@related or= {})[key] = value
 
     resp[resourceName] or resp

--- a/app/models/relations/index.coffee
+++ b/app/models/relations/index.coffee
@@ -38,13 +38,23 @@ module.exports =
   #
   loadRelatedCollection: (key) ->
 
-    if  modelLinks = @get('links')?[key]
+    resourceName = key
+
+    if relationship = _.findWhere @relations, { key }
+
+      if collectionType = relationship.collectionType
+        resourceName = _.result collectionType.prototype, 'resourceName'
+
+    if modelLinks = @get('links')?[key]
 
       # Convert ['1', '2'] to [1, 2]
       modelLinks = _.map modelLinks, (id) ->
         parseInt id
 
-      if relatedObjects = @related?[key] or @collection?.related?[key]
+      relatedObjects = @related?[resourceName] or
+        @collection?.related?[resourceName]
+
+      if relatedObjects
 
         return _.filter relatedObjects, (related) ->
           related.id in modelLinks

--- a/test/models/relations/link_relations.coffee
+++ b/test/models/relations/link_relations.coffee
@@ -270,6 +270,54 @@ describe 'Relations links', ->
         otherTodos.should.have.length 3
         otherTodos.at(1).get('title').should.equal 'Todo #3'
 
+      it 'should load compound documents using the resourceName of the collection', ->
+
+        { ProjectCollection, TodoCollection } = @classes
+
+        projects = new ProjectCollection
+
+        TodoCollection::resourceName = 'tasks'
+
+        data =
+          links:
+            "projects.todos":
+              href: '/todos/{projects.todos}'
+              type: 'todos'
+          projects: [
+            id: 1
+            name: 'My Project'
+            links:
+              todos: ['2', '4']
+          ,
+            id: 2
+            name: 'My Other Project'
+            links:
+              todos: [1, 3, 4]
+          ]
+          tasks: [
+            id: 1
+            title: 'Todo #1'
+          ,
+            id: 2
+            title: 'Todo #2'
+          ,
+            id: 3
+            title: 'Todo #3'
+          ,
+            id: 4
+            title: 'Todo #4'
+          ]
+
+        projects.set projects.parse data
+
+        todos = projects.get(1).get 'todos'
+
+        url = _.result todos, 'url'
+
+        url.should.equal '/todos/2,4'
+
+        todos.should.have.length 2
+
   describe 'HasOne relationships', ->
 
     it 'should load the url from the parent', ->

--- a/test/models/relations/link_relations.coffee
+++ b/test/models/relations/link_relations.coffee
@@ -318,6 +318,48 @@ describe 'Relations links', ->
 
         todos.should.have.length 2
 
+      it 'should support self-referential compound documents', ->
+
+        { Project, ProjectCollection, TodoCollection } = @classes
+
+        Project::relations.push
+          type: 'HasMany'
+          key: 'children'
+          collectionType: ProjectCollection
+
+        projects = new ProjectCollection
+
+        TodoCollection::resourceName = 'tasks'
+
+        data =
+          links:
+            "projects.children": '/projects/{projects.id}/children'
+          projects: [
+            id: 1
+            name: 'My Project'
+            links:
+              children: [2, 3]
+          ,
+            id: 2
+            name: 'Project #2'
+          ,
+            id: 3
+            name: 'Project #3'
+          ,
+            id: 4
+            name: 'Project #4'
+          ]
+
+        projects.set projects.parse data
+
+        children = projects.get(1).get 'children'
+
+        url = _.result children, 'url'
+
+        url.should.equal '/projects/1/children'
+
+        children.should.have.length 2
+
   describe 'HasOne relationships', ->
 
     it 'should load the url from the parent', ->


### PR DESCRIPTION
The comments in the commits provide the details for this PR, but the basic goal was to support the following API for sections:

``` coffeescript
sections: [
  id: 1
  name: 'Home'
  links:
    children: [2, 3]
,
  id: 2
  name: 'Child 1'
,
  id: 3
  name: 'Child 2'
]
```
