### PR TITLE
Add deferreds to controllers/views

### DIFF
--- a/app/views/base/extensions/promise.coffee
+++ b/app/views/base/extensions/promise.coffee
@@ -1,0 +1,63 @@
+module.exports =
+
+  # If a `promise` is passed as an option to the view instance, display a
+  # loading indicator (by default) and wait until the promise is fulfilled
+  # before rendering the view.
+  initPromise: ->
+
+    promise = @options.promise
+
+    return unless promise and promise.state() isnt 'resolved'
+
+    # We'll render once the promise is fulfilled.
+    @autoRender = false
+
+    # We want to be able to show the loading indicator, so let's go ahead and
+    # attach the element to the DOM.
+    if @autoAttach
+      @attach()
+      @autoAttach = false
+
+    @$el.addClass 'loading'
+
+    $loadingIndicator = @renderLoadingIndicator.apply this
+
+    removeLoadingIndicator = ->
+      $loadingIndicator?.remove()
+      $loadingIndicator = null
+
+    # When the promise is fulfilled, remove the loading indicator and the
+    # `loading` class, then render the view.
+    promise.done =>
+      removeLoadingIndicator()
+      @$el.removeClass 'loading'
+      @render()
+
+    # Wrap the `dispose` method to remove the loading indicator if it exists.
+    #
+    # This may be necessary if the view is disposed before the promise is
+    # resolved. While the `loadingIndicator` may be a child of the view's
+    # element which would be removed during disposal anyway, there's nothing
+    # preventing the loadingIndicator from being attached to another element
+    # (such as the `body`).
+    dispose = @dispose
+
+    @dispose = =>
+      return false if @disposed
+      removeLoadingIndicator()
+      dispose.apply this, arguments
+
+  # Render the `loadingIndicator` and return it from this method to make sure
+  # it's properly removed when the promise is resolved or the view is
+  # disposed.
+  #
+  # The default behavior is to create a paragraph with class of `loading-
+  # text` and append it to the view's element. The text of the paragraph will
+  # be either the `loadingText` option passed to the view or 'Loading...' if
+  # that option is not provided.
+  renderLoadingIndicator: ->
+
+    if loadingText = @options.loadingText ? 'Loading...'
+
+      $("<p class='loading-text'>#{loadingText}</p>")
+        .appendTo @$el

--- a/app/views/base/index.coffee
+++ b/app/views/base/index.coffee
@@ -1,12 +1,19 @@
 Chaplin = require 'chaplin'
 
 EventExtensions = require 'core/lib/event_extensions'
+PromiseExtensions = require './extensions/promise'
 
 module.exports = class BaseView extends Chaplin.View
 
-  _.extend @prototype, EventExtensions
+  _.extend @prototype, EventExtensions, PromiseExtensions
 
   autoRender: true
+
+  initialize: ->
+
+    @initPromise()
+
+    super
 
   getTemplateFunction: ->
     throw new Error '@template is required' unless @template?

--- a/test/views/base/extensions/promise.coffee
+++ b/test/views/base/extensions/promise.coffee
@@ -1,0 +1,126 @@
+Chaplin = require 'chaplin'
+
+BaseView = require 'core/views/base'
+
+describe 'The BaseView with promises', ->
+
+  beforeEach ->
+
+    @promise = new $.Deferred()
+
+    class TestView extends BaseView
+
+      render: ->
+        @$el.html 'Test'
+        @
+
+    @classes = { TestView }
+
+    @testView = new TestView { @promise }
+
+  it 'should not autoRender the view', ->
+
+    @testView.$el.should.not.contain 'Test'
+
+  it 'should render the view when the promise is fulfilled', ->
+
+    @promise.resolve()
+
+    @testView.$el.should.contain 'Test'
+
+  it 'should autoRender the view if the promise is already resolved', ->
+
+    { TestView } = @classes
+
+    @promise.resolve()
+
+    customTestView = new TestView { @promise }
+
+    customTestView.$el.should.contain 'Test'
+
+  describe 'loading state', ->
+
+    it 'should have the "loading" class during fulfillment', ->
+
+      @testView.$el.should.have.class 'loading'
+
+      @promise.resolve()
+
+      @testView.$el.should.not.have.class 'loading'
+
+    it 'should show the loading text during fulfillment', ->
+
+      @testView.$el.should.contain 'Loading...'
+
+      @promise.resolve()
+
+      @testView.$el.should.not.contain 'Loading...'
+
+    it 'should show custom loading text if provided', ->
+
+      { TestView } = @classes
+
+      loadingText = 'Loading details...'
+
+      customTestView = new TestView { @promise, loadingText }
+
+      customTestView.$el.should.contain loadingText
+
+      @promise.resolve()
+
+      customTestView.$el.should.not.contain loadingText
+
+    describe 'custom loading indicator', ->
+
+      beforeEach ->
+
+        class CustomLoadingTestView extends BaseView
+
+          render: ->
+            @$el.html 'Test'
+            @
+
+          renderLoadingIndicator: ->
+
+            $('<div class="loading-alert">Loading!</div>').
+              appendTo $ 'body'
+
+        @customView = new CustomLoadingTestView { @promise }
+
+      it 'should be removed on resolve', ->
+
+        $loadingMessage = $('body').find '.loading-alert'
+
+        $loadingMessage.should.exist
+        $loadingMessage.should.contain 'Loading!'
+
+        @promise.resolve()
+
+        $loadingMessage = $('body').find '.loading-alert'
+
+        $loadingMessage.should.not.exist
+
+      it 'should be removed on disposal of the view', ->
+
+        $loadingMessage = $('body').find '.loading-alert'
+
+        $loadingMessage.should.exist
+
+        @customView.dispose()
+
+        $loadingMessage = $('body').find '.loading-alert'
+
+        $loadingMessage.should.not.exist
+
+      it 'should not cause a problem if the view is disposed after resolution', ->
+
+        $loadingMessage = $('body').find '.loading-alert'
+
+        $loadingMessage.should.exist
+
+        @promise.resolve()
+        @customView.dispose()
+
+        $loadingMessage = $('body').find '.loading-alert'
+
+        $loadingMessage.should.not.exist


### PR DESCRIPTION
We need to be able to prevent a view from being displayed until a promise has been fulfilled. Otherwise an incomplete view may be displayed. We may also want to show a "Loading..." view while the promise is being fulfilled.

I have some ideas but will look through the Chaplin documentation and issues first to see if someone else has already solved this problem.
