### PR TITLE
Support grandchildren in self-referrential models

### DIFF
--- a/app/models/base.coffee
+++ b/app/models/base.coffee
@@ -3,6 +3,7 @@ Chaplin = require 'chaplin'
 EventExtensions = require 'core/lib/event_extensions'
 RelationExtensions = require './relations'
 LinkExtensions = require './links'
+IdentityMapExtensions = require './extensions/identity_map'
 
 class BaseModel extends Chaplin.Model
 
@@ -50,6 +51,7 @@ class BaseCollection extends Chaplin.Collection
 
   _.extend @prototype,
     EventExtensions,
+    IdentityMapExtensions,
     Chaplin.SyncMachine
 
   initialize: ->

--- a/app/models/base.coffee
+++ b/app/models/base.coffee
@@ -47,6 +47,9 @@ class BaseModel extends Chaplin.Model
 
     _.first(resp?[@resourceName]) or resp
 
+  _getResourceArray: (key) ->
+    @related?[key] or @collection?._getResourceArray key
+
 class BaseCollection extends Chaplin.Collection
 
   _.extend @prototype,
@@ -99,5 +102,8 @@ class BaseCollection extends Chaplin.Collection
     else
 
       $.Deferred (d) -> d.resolve()
+
+  _getResourceArray: (key) ->
+    @related[key]
 
 module.exports = { BaseModel, BaseCollection }

--- a/app/models/base.coffee
+++ b/app/models/base.coffee
@@ -85,10 +85,19 @@ class BaseCollection extends Chaplin.Collection
 
     resp[resourceName] or resp
 
-  fetch: ->
+  fetch: (options = {}) ->
 
-    @beginSync()
+    _(options).defaults
+      force: false
 
-    super.done => @finishSync()
+    if options.force or not @isSynced()
+
+      @beginSync()
+
+      super.done => @finishSync()
+
+    else
+
+      $.Deferred (d) -> d.resolve()
 
 module.exports = { BaseModel, BaseCollection }

--- a/app/models/extensions/identity_cache.coffee
+++ b/app/models/extensions/identity_cache.coffee
@@ -1,0 +1,7 @@
+cache = {}
+
+module.exports =
+
+  getOrCreate: (key) -> cache[key] ?= {}
+
+  clear: -> cache = {}

--- a/app/models/extensions/identity_map.coffee
+++ b/app/models/extensions/identity_map.coffee
@@ -1,0 +1,36 @@
+IdentityCache = require './identity_cache'
+
+module.exports =
+
+  _prepareModel: (attrs, options = {}) ->
+
+    if attrs instanceof Backbone.Model
+      attrs.collection ?= this
+      return
+
+    options.collection = this
+
+    idAttribute = @model?::idAttribute
+
+    if id = attrs[idAttribute]
+
+      cache = IdentityCache.getOrCreate @model
+
+      if cached = cache[attrs.id]
+
+        if id is 2
+          console.warn 'cached'
+
+        return cached
+      else
+
+        model = new @model attrs, options
+
+        unless model._validate attrs, options
+          @trigger 'invalid', this, attrs, options
+          return false
+
+        if id is 2
+          console.warn 'not cached', model.collection?.related?
+
+        return cache[id] = model

--- a/app/models/extensions/identity_map.coffee
+++ b/app/models/extensions/identity_map.coffee
@@ -17,10 +17,6 @@ module.exports =
       cache = IdentityCache.getOrCreate @model
 
       if cached = cache[attrs.id]
-
-        if id is 2
-          console.warn 'cached'
-
         return cached
       else
 
@@ -29,8 +25,5 @@ module.exports =
         unless model._validate attrs, options
           @trigger 'invalid', this, attrs, options
           return false
-
-        if id is 2
-          console.warn 'not cached', model.collection?.related?
 
         return cache[id] = model

--- a/app/models/relations/has_many.coffee
+++ b/app/models/relations/has_many.coffee
@@ -36,7 +36,7 @@ updateCollection = (key, collectionType) ->
 
       @set key, collection, silent: true
 
-# Overwrite the default collection.url() method to look for the link at `key`.
+# Override the default collection.url() method to look for the link at `key`.
 # This needs to happen at the time the url is requested as the link may not
 # have been available when the association was first created.
 buildCollectionUrl = (collection, key) ->

--- a/app/models/relations/has_many.coffee
+++ b/app/models/relations/has_many.coffee
@@ -29,6 +29,9 @@ updateCollection = (key, collectionType) ->
 
       collection = new collectionType value
 
+      if related = @collection?.related
+        collection.related = related
+
       buildCollectionUrl.call this, collection, key
 
       @set key, collection, silent: true

--- a/app/models/relations/index.coffee
+++ b/app/models/relations/index.coffee
@@ -36,7 +36,8 @@ module.exports =
   #     name: 'Category 3'
   #   ]
   #
-  loadRelatedCollection: (key) ->
+  # Returns an array
+  loadRelatedObjects: (key) ->
 
     resourceName = key
 

--- a/app/models/relations/index.coffee
+++ b/app/models/relations/index.coffee
@@ -51,10 +51,7 @@ module.exports =
       modelLinks = _.map modelLinks, (id) ->
         parseInt id
 
-      relatedObjects = @related?[resourceName] or
-        @collection?.related?[resourceName]
-
-      if relatedObjects
+      if relatedObjects = @_getResourceArray resourceName
 
         return _.filter relatedObjects, (related) ->
           related.id in modelLinks

--- a/test/models/base.coffee
+++ b/test/models/base.coffee
@@ -166,6 +166,49 @@ describe 'Base collection', ->
 
       (new ProjectCollection).url().should.equal '/projects'
 
+  describe 'fetch', ->
+
+    beforeEach ->
+
+      class Project extends BaseModel
+
+        urlRoot: '/projects'
+
+      class ProjectCollection extends BaseCollection
+
+        model: Project
+
+      @projects = new ProjectCollection
+
+      @classes = { Project, ProjectCollection }
+
+    it 'should hit the backend by default', (done) ->
+
+      @projects.sync = ->
+        done()
+
+      @projects.fetch()
+
+    describe 'synced collection', ->
+
+      beforeEach ->
+
+        @projects.beginSync()
+        @projects.finishSync()
+
+      it 'should not hit the backend if the collection is already synced', (done) ->
+
+        @projects.fetch().done ->
+          done()
+
+      it 'should hit the backend if forced to do so', (done) ->
+
+        @projects.sync = ->
+          done()
+
+        @projects.fetch
+          force: true
+
   describe 'event extensions', ->
 
     it 'should support onAndTrigger', (done) ->

--- a/test/models/identity_map.coffee
+++ b/test/models/identity_map.coffee
@@ -1,0 +1,65 @@
+{ BaseModel, BaseCollection } = require 'core/models/base'
+
+IdentityCache = require 'core/models/extensions/identity_cache'
+
+describe 'Identity map', ->
+
+  beforeEach ->
+
+    class Project extends BaseModel
+
+    class ProjectCollection extends BaseCollection
+
+      model: Project
+
+    @classes = { Project, ProjectCollection }
+
+  describe 'collection.add', ->
+
+    it 'should use the same model', ->
+
+      { ProjectCollection } = @classes
+
+      projectCollection = new ProjectCollection
+
+      projectCollection.add
+        id: 1
+        name: 'Testing'
+
+      project = projectCollection.get 1
+
+      otherProjectCollection = new ProjectCollection
+
+      otherProjectCollection.add
+        id: 1
+        name: 'Testing'
+
+      sameProject = otherProjectCollection.get 1
+
+      project.should.equal sameProject
+
+  describe 'clear', ->
+
+    it 'should be able to clear the cache', ->
+
+      { ProjectCollection } = @classes
+
+      projectCollection = new ProjectCollection
+
+      projectCollection.add
+        id: 1
+        name: 'Testing'
+
+      project = projectCollection.get 1
+
+      IdentityCache.clear()
+
+      otherProjectCollection = new ProjectCollection
+
+      otherProjectCollection.add
+        id: 1
+        name: 'Testing'
+
+      sameProject = otherProjectCollection.get 1
+
+      project.should.not.equal sameProject

--- a/test/models/relations/compound_documents.coffee
+++ b/test/models/relations/compound_documents.coffee
@@ -1,0 +1,197 @@
+{ BaseModel, BaseCollection } = require 'core/models/base'
+
+IdentityCache = require 'core/models/extensions/identity_cache'
+
+describe 'Compound documents', ->
+
+  beforeEach ->
+
+    IdentityCache.clear()
+
+    class Todo extends BaseModel
+
+    class TodoCollection extends BaseCollection
+
+      model: Todo
+
+      resourceName: 'todos'
+
+      url: '/todos'
+
+    class Project extends BaseModel
+
+      resourceName: 'projects'
+
+      relations: [
+        type: 'HasMany'
+        key: 'todos'
+        collectionType: TodoCollection
+      ]
+
+    class ProjectCollection extends BaseCollection
+
+      model: Project
+
+    @classes = { Project, ProjectCollection, TodoCollection }
+
+  describe 'Single level', ->
+
+    beforeEach ->
+
+      { ProjectCollection, TodoCollection } = @classes
+
+      @projects = new ProjectCollection
+
+      data =
+        links:
+          'projects.todos': '/todos/{projects.todos}'
+        projects: [
+          id: 1
+          name: 'My Project'
+          links:
+            todos: [2, 4]
+        ,
+          id: 2
+          name: 'My Other Project'
+          links:
+            todos: [1, 3, 4]
+        ]
+        todos: [
+          id: 1
+          title: 'Todo #1'
+        ,
+          id: 2
+          title: 'Todo #2'
+        ,
+          id: 3
+          title: 'Todo #3'
+        ,
+          id: 4
+          title: 'Todo #4'
+        ]
+
+      @projects.set @projects.parse data
+
+      @project = @projects.get 1
+
+      @todos = @project.get 'todos'
+
+    it 'should create an empty collection by default', ->
+
+      @todos.should.have.length 0
+
+    it 'should have related models', ->
+
+      models = @project._getResourceArray 'todos'
+
+      expect(models).to.be.ok
+
+      models.should.have.length 4
+
+    it 'should be able to load only the models linked to this project', ->
+
+      todoObjects = @project.loadRelatedObjects 'todos'
+
+      todoObjects.should.have.length 2
+
+    it 'should load the collection on fetch without hitting the API', (done) ->
+
+      @todos.fetch().done =>
+
+        @todos.should.have.length 2
+
+        @todos.isSynced().should.be.true
+
+        done()
+
+    it 'should hit the API if forced to do so', (done) ->
+
+      @todos.sync = ->
+        done()
+
+      @todos.fetch
+        force: true
+
+  describe 'Nested sets', ->
+
+    beforeEach ->
+
+      { Project, ProjectCollection, TodoCollection } = @classes
+
+      Project::relations.push
+        type: 'HasMany'
+        key: 'children'
+        collectionType: ProjectCollection
+
+      @projects = new ProjectCollection
+
+      data =
+        links:
+          "projects.children": '/projects/{projects.id}/children'
+        projects: [
+          id: 1
+          name: 'My Project'
+          links:
+            children: [2, 3]
+        ,
+          id: 2
+          name: 'Project #2'
+        ,
+          id: 3
+          name: 'Project #3'
+          links:
+            children: [4]
+        ,
+          id: 4
+          name: 'Project #4'
+        ]
+
+      @projects.set @projects.parse data
+
+      @project = @projects.get 1
+
+      @children = @project.get 'children'
+
+    it 'should create an empty collection by default', ->
+
+      @children.should.have.length 0
+
+    it 'should have related models', ->
+
+      models = @project._getResourceArray 'projects'
+
+      expect(models).to.be.ok
+
+      models.should.have.length 4
+
+    it 'should be able to load only the models linked to this project', ->
+
+      childObjects = @project.loadRelatedObjects 'children'
+
+      childObjects.should.have.length 2
+
+    it 'should load the collection on fetch without hitting the API', (done) ->
+
+      @children.fetch().done =>
+
+        @children.should.have.length 2
+
+        @children.isSynced().should.be.true
+
+        done()
+
+    it 'should load the collection at lower levels', (done) ->
+
+      @children.fetch().done =>
+
+        child = @children.get 3
+
+        grandChildren = child.get 'children'
+
+        grandChildren.should.have.length 0
+
+        grandChildren.fetch().done ->
+
+          grandChildren.should.have.length 1
+
+          done()

--- a/test/models/relations/has_many.coffee
+++ b/test/models/relations/has_many.coffee
@@ -1,8 +1,12 @@
 { BaseModel, BaseCollection } = require 'core/models/base'
 
+IdentityCache = require 'core/models/extensions/identity_cache'
+
 describe 'Relations (Has Many)', ->
 
   beforeEach ->
+
+    IdentityCache.clear()
 
     class TodoCollection extends BaseCollection
 

--- a/test/models/relations/link_relations.coffee
+++ b/test/models/relations/link_relations.coffee
@@ -1,8 +1,12 @@
 { BaseModel, BaseCollection } = require 'core/models/base'
 
+IdentityCache = require 'core/models/extensions/identity_cache'
+
 describe 'Relations links', ->
 
   beforeEach ->
+
+    IdentityCache.clear()
 
     class CommentCollection extends BaseCollection
 

--- a/test/models/relations/link_relations.coffee
+++ b/test/models/relations/link_relations.coffee
@@ -345,6 +345,8 @@ describe 'Relations links', ->
           ,
             id: 3
             name: 'Project #3'
+            links:
+              children: [4]
           ,
             id: 4
             name: 'Project #4'
@@ -359,6 +361,12 @@ describe 'Relations links', ->
         url.should.equal '/projects/1/children'
 
         children.should.have.length 2
+
+        child = children.get 3
+
+        grandchildren = child.get 'children'
+
+        grandchildren.should.have.length 1
 
   describe 'HasOne relationships', ->
 


### PR DESCRIPTION
The goal is to support:

``` coffeescript
links:
  'sections.children': '/sections/{sections.id}/children'
sections = [
  id: 1
  name: 'Home'
  parent_id: null
  links:
    children: [2, 3]
,
  id: 2
  name: 'Child 1'
  links:
    children: [4, 5]
,
  id: 3
  name: 'Child 2'
,
  id: 4
  name: 'Grandchild 1'
,
  id: 5
  name: 'Grandchild 2'
]
```
