### PR TITLE
Added `Presenter` class

### DIFF
--- a/app/presenters/base.coffee
+++ b/app/presenters/base.coffee
@@ -1,0 +1,17 @@
+Chaplin = require 'chaplin'
+
+EventExtensions = require 'core/lib/event_extensions'
+
+class Presenter extends Chaplin.Model
+
+  _.extend @prototype,
+    EventExtensions
+
+class PresenterCollection extends Chaplin.Collection
+
+  model: Presenter
+
+  _.extend @prototype,
+    EventExtensions
+
+module.exports = { Presenter, PresenterCollection }

--- a/app/views/base/collection.coffee
+++ b/app/views/base/collection.coffee
@@ -9,4 +9,15 @@ module.exports = class BaseCollectionView extends Chaplin.CollectionView
   # Animation shouldn't be done via JS - it's too slow.
   useCssAnimation: true
 
+  optionNames: Chaplin.CollectionView::optionNames.concat ['presenter']
+
   getTemplateFunction: -> @template
+
+  render: ->
+
+    super
+
+    if @presenterBindings and @presenter
+      @stickit @presenter, @presenterBindings
+
+    @

--- a/app/views/base/index.coffee
+++ b/app/views/base/index.coffee
@@ -9,6 +9,8 @@ module.exports = class BaseView extends Chaplin.View
 
   autoRender: true
 
+  optionNames: Chaplin.View::optionNames.concat ['presenter']
+
   initialize: ->
 
     @initPromise()
@@ -30,5 +32,8 @@ module.exports = class BaseView extends Chaplin.View
 
     if @bindings and @model
       @stickit()
+
+    if @presenterBindings and @presenter
+      @stickit @presenter, @presenterBindings
 
     @

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -4,3 +4,5 @@ $ = require 'jquery'
 Backbone = require 'backbone'
 
 Backbone.$ = $
+
+require 'stickit'

--- a/test/presenters/base.coffee
+++ b/test/presenters/base.coffee
@@ -1,0 +1,51 @@
+{ Presenter, PresenterCollection } = require 'core/presenters/base'
+
+describe 'Presenter', ->
+
+  beforeEach ->
+    @presenter = new Presenter
+
+
+  it 'should be a Backbone.Model', ->
+    @presenter.should.be.an.instanceof Backbone.Model
+
+  describe 'event extensions', ->
+
+    it 'should support onAndTrigger', (done) ->
+
+      @presenter.onAndTrigger 'someEvent', ->
+        done()
+
+    it 'should support listenToAndTrigger', (done) ->
+
+      otherPresenter = new Presenter
+      presenter = @presenter
+
+      @presenter.listenToAndTrigger otherPresenter, 'someEvent', ->
+        this.should.equal presenter
+        done()
+
+describe 'PresenterCollection', ->
+
+  beforeEach ->
+    @collection = new PresenterCollection
+
+  it 'should be a Backbone.Collection', ->
+    @collection.should.be.an.instanceof Backbone.Collection
+
+  describe 'event extensions', ->
+
+    it 'should support onAndTrigger', (done) ->
+
+      @collection.onAndTrigger 'someEvent', ->
+        done()
+
+    it 'should support listenToAndTrigger', (done) ->
+
+      collection = @collection
+
+      presenter = new Presenter
+
+      @collection.listenToAndTrigger presenter, 'someEvent', ->
+        this.should.equal collection
+        done()

--- a/test/views/base/collection.coffee
+++ b/test/views/base/collection.coffee
@@ -12,3 +12,45 @@ describe 'BaseCollectionView', ->
       collection: new Chaplin.Collection
 
     view.useCssAnimation.should.be.ok
+
+  describe 'Presenter', ->
+
+    it 'should pass the presenter as a first-class attribute', ->
+
+      { Presenter } = require 'core/presenters/base'
+
+      presenter = new Presenter
+
+      view = new BaseCollectionView
+        collection: new Chaplin.Collection
+        presenter: presenter
+
+      expect(view.presenter).to.be.ok
+
+      view.presenter.should.equal presenter
+
+    it 'should add stickit bindings if presenter and presenterBindings are available', ->
+
+      { Presenter } = require 'core/presenters/base'
+
+      presenter = new Presenter
+        expanded: false
+
+      class SampleView extends BaseCollectionView
+
+        presenterBindings:
+          ':el':
+            observe: 'expanded'
+            update: ($el, val) -> $el.toggleClass 'expanded', val
+
+      view = new SampleView
+        collection: new Chaplin.Collection
+        presenter: presenter
+
+      view.$el.should.not.have.class 'expanded'
+
+      presenter.set
+        expanded: true
+
+      view.$el.should.have.class 'expanded'
+

--- a/test/views/base/index.coffee
+++ b/test/views/base/index.coffee
@@ -122,3 +122,46 @@ describe 'The BaseView', ->
 
       data.name.should.equal 'Some Name'
       data.options.title.should.equal 'Some Other Title'
+
+  describe 'Presenter', ->
+
+    it 'should pass the presenter as a first-class attribute', ->
+
+      { Presenter } = require 'core/presenters/base'
+
+      presenter = new Presenter
+
+      view = new BaseView
+        autoRender: false
+        presenter: presenter
+
+      expect(view.presenter).to.be.ok
+
+      view.presenter.should.equal presenter
+
+    it 'should add stickit bindings if presenter and presenterBindings are available', ->
+
+      { Presenter } = require 'core/presenters/base'
+
+      presenter = new Presenter
+        expanded: false
+
+      class SampleView extends BaseView
+
+        template: -> ''
+
+        presenterBindings:
+          ':el':
+            observe: 'expanded'
+            update: ($el, val) -> $el.toggleClass 'expanded', val
+
+      view = new SampleView
+        presenter: presenter
+
+      view.$el.should.not.have.class 'expanded'
+
+      presenter.set
+        expanded: true
+
+      view.$el.should.have.class 'expanded'
+


### PR DESCRIPTION
Presenters are simple models that can be use to store data and logic
related to a view. For instance, a presenter might store the state of an
expandable view and can be used as in `stickit`:

  class SomeView extends BaseView

```
events: 'toggle'

toggle: ->
  @presenter.set
    expanded: ! @presenter.get 'expanded'

presenterBindings:
  ':el':
    observe: 'expanded'
    update: ($el, val) -> $el.toggleClass 'expanded', val

initialize: ->
  @presenter = new Presenter
    expanded: false

  super
```
