### PR TITLE
Add presenter support to delegateListeners

### DIFF
--- a/app/views/base/index.coffee
+++ b/app/views/base/index.coffee
@@ -37,3 +37,12 @@ module.exports = class BaseView extends Chaplin.View
       @stickit @presenter, @presenterBindings
 
     @
+
+  delegateListener: (eventName, target, callback) ->
+
+    if target is 'presenter'
+      @listenTo @presenter, eventName, callback if @presenter
+    else
+      super
+
+    return

--- a/test/views/base/index.coffee
+++ b/test/views/base/index.coffee
@@ -165,7 +165,7 @@ describe 'The BaseView', ->
 
       view.$el.should.have.class 'expanded'
 
-    it.only 'should add presenter support to the view listeners', ->
+    it 'should add presenter support to the view listeners', ->
 
       { Presenter } = require 'core/presenters/base'
 
@@ -177,7 +177,6 @@ describe 'The BaseView', ->
 
         listen:
           'someEvent presenter': ->
-            console.warn 'triggered'
             @eventTriggered = true
 
       view = new SampleView

--- a/test/views/base/index.coffee
+++ b/test/views/base/index.coffee
@@ -165,3 +165,26 @@ describe 'The BaseView', ->
 
       view.$el.should.have.class 'expanded'
 
+    it.only 'should add presenter support to the view listeners', ->
+
+      { Presenter } = require 'core/presenters/base'
+
+      presenter = new Presenter
+
+      class SampleView extends BaseView
+
+        template: -> ''
+
+        listen:
+          'someEvent presenter': ->
+            console.warn 'triggered'
+            @eventTriggered = true
+
+      view = new SampleView
+        presenter: presenter
+
+      expect(view.eventTriggered).to.not.be.true
+
+      presenter.trigger 'someEvent'
+
+      expect(view.eventTriggered).to.be.true


### PR DESCRIPTION
This allows views to listen to presenter events using the declarative `listen` attribute:

``` coffeescript
class SampleView extends BaseView

  listen:
    'someEvent presenter': ->
      @eventTriggered = true
```

This declarative support is provided by [Chaplin.View](http://docs.chaplinjs.org/chaplin.view.html) but we added special handler support for the `presenter` attribute.
