### PR TITLE
Added BaseApplication with loading view

### DIFF
--- a/app/application/base.coffee
+++ b/app/application/base.coffee
@@ -1,0 +1,32 @@
+Chaplin = require 'chaplin'
+
+LoadingView = require 'core/views/loading'
+
+module.exports = class BaseApplication extends Chaplin.Application
+
+  initialize: ->
+
+    @initLoadingView()
+
+    super
+
+  initLoadingView: ->
+
+    @subscribeEvent 'dispatcher:dispatch', (controller) =>
+
+      if promise = controller.promise
+
+        return if promise.state() is 'resolved'
+
+        @showLoadingView controller
+
+  showLoadingView: (controller) ->
+
+    loadingView = new LoadingView
+      loadingMessage: controller.loadingMessage
+      region: controller.region or 'content'
+
+    controller.promise.done ->
+      loadingView.dispose()
+
+    loadingView

--- a/app/views/loading/index.coffee
+++ b/app/views/loading/index.coffee
@@ -1,0 +1,19 @@
+BaseView = require 'core/views/base'
+
+module.exports = class LoadingView extends BaseView
+
+  className: 'loading-view'
+
+  initialize: (options) ->
+
+    _(options).defaults
+      loadingMessage: 'Loading...'
+
+    super
+
+  render: ->
+
+    @$el.html @options.loadingMessage
+
+    @
+

--- a/app/views/loading/template.jade
+++ b/app/views/loading/template.jade
@@ -1,0 +1,1 @@
+= options.loadingMessage

--- a/test/app/index.coffee
+++ b/test/app/index.coffee
@@ -1,0 +1,98 @@
+BaseApplication = require 'core/application/base'
+BaseView = require 'core/views/base'
+
+LoadingView = require 'core/views/loading'
+
+describe 'BaseApplication', ->
+
+  describe 'loading view', ->
+
+    beforeEach ->
+
+      class MyApplication extends BaseApplication
+
+      @application = new MyApplication
+
+      class WrapperView extends BaseView
+
+        regions:
+          'content': '.content'
+
+        template: -> ''
+
+      # Register 'content' region
+      new WrapperView
+
+      sinon.spy MyApplication.prototype, 'showLoadingView'
+
+      @classes = { MyApplication }
+
+    afterEach ->
+
+      { MyApplication } = @classes
+
+      @application.dispose()
+
+      MyApplication::showLoadingView.restore()
+
+    it 'should show the loading view if a dispatched controller has an unresolved promise', ->
+
+      promise = new $.Deferred()
+
+      controller = { promise }
+
+      @application.showLoadingView.should.not.have.been.called
+
+      @application.publishEvent 'dispatcher:dispatch', controller
+
+      @application.showLoadingView.should.have.been.calledOnce
+
+    it 'should not show the loading view if the dispatched controller has an resolved promise', ->
+
+      promise = new $.Deferred()
+
+      promise.resolve()
+
+      controller = { promise }
+
+      @application.showLoadingView.should.not.have.been.called
+
+      @application.publishEvent 'dispatcher:dispatch', controller
+
+      @application.showLoadingView.should.not.have.been.called
+
+    it 'should pass the controller to showLoadingView', ->
+
+      promise = new $.Deferred()
+
+      controller = { promise }
+
+      @application.showLoadingView.should.not.have.been.called
+
+      @application.publishEvent 'dispatcher:dispatch', controller
+
+      @application.showLoadingView.should.have.been.calledWith controller
+
+    describe 'LoadingView', ->
+
+      beforeEach =>
+
+      it 'should create a LoadingView', ->
+
+        promise = new $.Deferred()
+
+        view = @application.showLoadingView
+          promise: promise
+          loadingMessage: 'Testing'
+
+        expect(view).to.be.ok
+
+        view.should.be.an.instanceof LoadingView
+
+        view.$el.should.contain 'Testing'
+
+        view.disposed.should.be.false
+
+        promise.resolve()
+
+        view.disposed.should.be.true


### PR DESCRIPTION
Now if a controller has an unresolved `promise` attribute then the
BaseApplication's `showLoadingView` will be called and will, by default,
instantiate and display a LoadingView (also new) with the controller's
`loadingMessage` attribute (or "Loading..." by default) and the
controller's `loadingRegion` attribute (or 'content' by default').
