### PR TITLE
Add `hideIfEmpty` option to BaseCollectionView

### DIFF
--- a/app/views/base/collection.coffee
+++ b/app/views/base/collection.coffee
@@ -2,6 +2,8 @@ Chaplin = require 'chaplin'
 
 EventExtensions = require 'core/lib/event_extensions'
 
+{ Presenter } = require 'core/presenters/base'
+
 module.exports = class BaseCollectionView extends Chaplin.CollectionView
 
   _.extend @prototype, EventExtensions
@@ -9,7 +11,10 @@ module.exports = class BaseCollectionView extends Chaplin.CollectionView
   # Animation shouldn't be done via JS - it's too slow.
   useCssAnimation: true
 
-  optionNames: Chaplin.CollectionView::optionNames.concat ['presenter']
+  optionNames: Chaplin.CollectionView::optionNames.concat [
+    'hideIfEmpty'
+    'presenter'
+  ]
 
   getTemplateFunction: -> @template
 
@@ -17,7 +22,36 @@ module.exports = class BaseCollectionView extends Chaplin.CollectionView
 
     super
 
+    @initHideIfEmpty()
+
     if @presenterBindings and @presenter
       @stickit @presenter, @presenterBindings
 
     @
+
+   #  We use a Presenter with an `empty` attribute. This way we only toggle
+   #  the visibility when the value of `empty` changes. A potentially more
+   #  straightforward approach would be to use something like:
+
+   #    `@$el.toggle ! @collection.isEmpty()`
+
+   #  However we introduced the presenter under the admittedly intution-
+   #  driven assumption that the jQuery code for determining whether to
+   #  toggle the element (which requires determing the current visibility) is
+   #  heavier than the Backbone.Model approach of checking the existing value
+   #  of a hash attribute.
+  initHideIfEmpty: ->
+
+    return unless @hideIfEmpty
+
+    collectionPresenter = new Presenter
+
+    @listenToAndTrigger @collection, 'add remove reset', ->
+
+      collectionPresenter.set
+        empty: @collection.isEmpty()
+
+    @stickit collectionPresenter,
+      ':el':
+        observe: 'empty'
+        visible: (val) -> ! val

--- a/test/views/base/collection.coffee
+++ b/test/views/base/collection.coffee
@@ -1,5 +1,6 @@
 Chaplin = require 'chaplin'
 
+BaseView = require 'core/views/base'
 BaseCollectionView = require 'core/views/base/collection'
 
 describe 'BaseCollectionView', ->
@@ -54,3 +55,141 @@ describe 'BaseCollectionView', ->
 
       view.$el.should.have.class 'expanded'
 
+  describe 'hideIfEmpty', ->
+
+    beforeEach ->
+
+      class ItemView extends BaseView
+
+        render: ->
+
+          @$el.html @id
+
+          this
+
+      class SampleView extends BaseCollectionView
+
+        itemView: ItemView
+
+      class HiddenSampleView extends BaseCollectionView
+
+        hideIfEmpty: true
+
+        itemView: ItemView
+
+      @classes = { SampleView, HiddenSampleView }
+
+    it 'should pass the "hideIfEmpty" property to the view', ->
+
+      { SampleView } = @classes
+
+      collection = new Chaplin.Collection
+
+      view = new SampleView
+        collection: collection
+        hideIfEmpty: true
+
+      view.options.hideIfEmpty.should.be.true
+
+    it 'should be able to hide the view if the collection is empty', ->
+
+      { SampleView, HiddenSampleView } = @classes
+
+      collection = new Chaplin.Collection
+
+      view = new SampleView
+        collection: collection
+
+      otherView = new HiddenSampleView
+        collection: collection
+
+      hiddenInOptionsView = new SampleView
+        collection: collection
+        hideIfEmpty: true
+
+      view.$el.should.not.have.css 'display', 'none'
+
+      otherView.$el.should.have.css 'display', 'none'
+
+      hiddenInOptionsView.$el.should.have.css 'display', 'none'
+
+    it 'should be able to hide the view if the collection is empty', ->
+
+      { SampleView, HiddenSampleView } = @classes
+
+      collection = new Chaplin.Collection
+
+      otherView = new HiddenSampleView
+        collection: collection
+
+      otherView.$el.should.have.css 'display', 'none'
+
+    it 'should be visible if the collection is populated', ->
+
+      { SampleView, HiddenSampleView } = @classes
+
+      collection = new Chaplin.Collection [
+        id: 1
+      ]
+
+      otherView = new HiddenSampleView
+        collection: collection
+
+      otherView.$el.should.not.have.css 'display', 'none'
+
+    it 'should be visible if the collection is populated later', ->
+
+      { SampleView, HiddenSampleView } = @classes
+
+      collection = new Chaplin.Collection
+
+      otherView = new HiddenSampleView
+        collection: collection
+
+      otherView.$el.should.have.css 'display', 'none'
+
+      collection.add [
+        id: 1
+      ]
+
+      otherView.$el.should.not.have.css 'display', 'none'
+
+    it 'should be hidden if the collection is empty later', ->
+
+      { SampleView, HiddenSampleView } = @classes
+
+      collection = new Chaplin.Collection [
+        id: 1
+      ]
+
+      otherView = new HiddenSampleView
+        collection: collection
+
+      otherView.$el.should.not.have.css 'display', 'none'
+
+      collection.remove 1
+
+      otherView.$el.should.have.css 'display', 'none'
+
+    it 'should be hidden if the collection is reset', ->
+
+      { SampleView, HiddenSampleView } = @classes
+
+      collection = new Chaplin.Collection [
+        id: 1
+      ]
+
+      otherView = new HiddenSampleView
+        collection: collection
+
+      otherView.$el.should.not.have.css 'display', 'none'
+
+      collection.reset()
+
+      otherView.$el.should.have.css 'display', 'none'
+
+      collection.reset [
+        id: 1
+      ]
+
+      otherView.$el.should.not.have.css 'display', 'none'


### PR DESCRIPTION
This will toggle the visibility of the view based on whether the collection is
empty.

A couple of notes:
- The visibility is not dependent on the sync status of the collection,
  so if the collection is empty because it hasn't been fetched then the
  view will still be hidden. If you'd like to show a "Loading" or
  "Empty" fallback then don't use this option.
- We use a Presenter with an `empty` attribute. This way we only toggle
  the visibility when the value of `empty` changes. A potentially
  more straightforward approach would be to use something like:
  
  `@$el.toggle ! @collection.isEmpty()`
  
  However we introduced the presenter under the admittedly intution-
  driven assumption that the jQuery code for determining whether to
  toggle the element (which requires determing the current visibility)
  is heavier than the Backbone.Model approach of checking the existing
  value of a hash attribute.
